### PR TITLE
Miscellaneous recommendations

### DIFF
--- a/header.php
+++ b/header.php
@@ -3,11 +3,7 @@
 	<head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-	<title><?php wp_title('&laquo;', true, 'right'); ?> <?php bloginfo('name'); ?></title>
-	<meta name="author" content="Roy Sivan">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<link rel="shortcut icon" href="/favicon.ico">
-	<link rel="apple-touch-icon" href="/favicon.png">
 	<?php wp_head(); ?>
 	<!--[if lt IE 9]>
 		<script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>


### PR DESCRIPTION
- `<meta name="author" content="Roy Sivan">` this is not needed, plugins should handle it.
- Remove `<title><?php wp_title('&laquo;', true, 'right'); ?> <?php bloginfo('name'); ?></title>` and use `add_theme_support( 'title-tag' );` instead.
- I would also remove 

```
    <link rel="shortcut icon" href="/favicon.ico">
    <link rel="apple-touch-icon" href="/favicon.png">
```

First there's no directory path and not to mention that WordPress is able to do this as well: https://make.wordpress.org/core/2015/07/27/site-icon/
